### PR TITLE
가게에 메뉴가 없는 경우, 다른 가게에서도 메뉴가 조회되지 않는 에러 해결

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -137,9 +137,9 @@ public class Main {
 
     static void getStores(User user) {
         long storeId = 0;
-        Menu menu = new Menu();
 
         while (storeId != -1) {
+            Menu menu = new Menu();
             storeId = storeController.getStoreCategories();
             if (storeId != -1)  {
                 while (menu != null) {


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
feature/main-page -> main

### 변경 사항
- 이전에는 Menu menu = new Menu(); 를 분기 밖에 둬서, 가게에 메뉴가 없는 경우, menu = null 처리가 되고 그 다음부터는 menu가 null이므로 분기를 타지 않았다.
```
    static void getStores(User user) {
        long storeId = 0;
        Menu menu = new Menu(); // 분기 밖에 설정되어 있음

        while (storeId != -1) {
            storeId = storeController.getStoreCategories();
            if (storeId != -1)  {
                while (menu != null) {
                    menu = menuController.getStoreMenus(storeId);
                    if (menu == null) break;
                    orderController.create(user, menu);
                }
            }
        }
    }
```

- Menu menu = new Menu(); 를 분기 안에 둬서 사용자가 다른 가게에 들어가면 새로 초기화되게끔 변경했습니다.
```
    static void getStores(User user) {
        long storeId = 0;

        while (storeId != -1) {
            Menu menu = new Menu(); // 이 부분 위치 수정
            storeId = storeController.getStoreCategories();
            if (storeId != -1)  {
                while (menu != null) {
                    menu = menuController.getStoreMenus(storeId);
                    if (menu == null) break;
                    orderController.create(user, menu);
                }
            }
        }
    }
```

### 테스트 결과
- 에러 해결