### PR TITLE
비회원도 주문이 가능한 에러 해결

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -40,7 +40,7 @@ public class Main {
                         }
                         break;
                     case 3:
-                        getStores(user);
+                        getStores(user, isLogin);
                         break;
                     case 0:
                     default:
@@ -52,7 +52,7 @@ public class Main {
                 option = scanner.nextInt();
                 switch (option) {
                     case 1:
-                        getStores(user);
+                        getStores(user, isLogin);
                         break;
                     case 2:
                         orderController.getUserOrders(user);
@@ -135,7 +135,7 @@ public class Main {
         System.out.print("입력: ");
     }
 
-    static void getStores(User user) {
+    static void getStores(User user, boolean isLogin) {
         long storeId = 0;
 
         while (storeId != -1) {
@@ -145,6 +145,10 @@ public class Main {
                 while (menu != null) {
                     menu = menuController.getStoreMenus(storeId);
                     if (menu == null) break;
+                    if (!isLogin) {
+                        printUnableOrderToNonMember();
+                        return;
+                    }
                     orderController.create(user, menu);
                 }
             }
@@ -153,6 +157,10 @@ public class Main {
 
     static void printExitMessage() {
         System.out.println("감사합니다! 또 오세요!");
+    }
+
+    static void printUnableOrderToNonMember() {
+        System.out.println("주문은 회원만 가능합니다. 로그인해주세요!\n");
     }
 
 }


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
feature/main-page -> main

### 변경 사항
- 주문할 때, 회원 여부 및 로그인 여부를 확인하지 않고 있었다.
```
                while (menu != null) {
                    menu = menuController.getStoreMenus(storeId);
                    if (menu == null) break;
                    orderController.create(user, menu); // 회원인지 아닌지 확인하지 않고 바로 주문이 넘어가고 있음.
                }
```

- 주문할 때, isLogin 확인하는 로직 추가했습니다.
```
                while (menu != null) {
                    menu = menuController.getStoreMenus(storeId);
                    if (menu == null) break;
                    if (!isLogin) {
                        printUnableOrderToNonMember();
                        return;
                    }
                    orderController.create(user, menu);
                }
```

- 비회원이 주문을 시도하면 "주문은 회원만 가능합니다. 로그인해주세요!" 메시지 출력 후 비회원 메인 페이지로 분기시킵니다.

### 테스트 결과
<img width="300" alt="image" src="https://github.com/user-attachments/assets/641276de-287c-44a6-b402-210a4aa8a8f1">

