### PR TITLE
옵션 이외의 입력이 들어왔을 때 예외처리 추가

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -28,7 +28,8 @@ public class Main {
         while (option != 0) {
             if (!isLogin) {
                 printNonMemberMainPage();
-                option = scanner.nextInt();
+                option = inputOption(scanner);
+                if (option == -1) continue;
                 switch (option) {
                     case 1:
                         userController.signUp();
@@ -49,7 +50,8 @@ public class Main {
                 }
             } else {
                 printMemberMainPage();
-                option = scanner.nextInt();
+                option = inputOption(scanner);
+                if (option == -1) continue;
                 switch (option) {
                     case 1:
                         getStores(user, isLogin);
@@ -133,6 +135,16 @@ public class Main {
         System.out.println("0. 종료");
         System.out.println("=====================================");
         System.out.print("입력: ");
+    }
+
+    static int inputOption(Scanner scanner) {
+        String input = scanner.next();
+        if (!input.equals("1") && !input.equals("2") && !input.equals("3") && !input.equals("0")) {
+            System.out.println("잘못된 입력입니다. 다시 입력해주세요.\n");
+            return -1;
+        }
+        int option = Integer.parseInt(input);
+        return option;
     }
 
     static void getStores(User user, boolean isLogin) {


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/main-page -> main

### 변경 사항
- 이전에는 메인 페이지에서 1,2,3,0 이외의 문자열이 들어오면 에러를 반환했습니다.
- 1,2,3,0 이외의 문자열이 들어오면 서비스를 종료시키지 않고, 잘못된 입력이니 다시 입력해달라는 메시지를 출력하고 다시 메인 페이지로 분기시키도록 변경했습니다.
- 추후에는 옵션을 리스트로 관리해서 확장성을 두면 좋을 것 같습니다.

### 테스트 결과
<img width="304" alt="image" src="https://github.com/user-attachments/assets/5630f53e-9c8d-4351-93fc-af6c44e315b2">

